### PR TITLE
Remove Travis build status from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Apache Fineract CN data-jpa [![Build Status](https://api.travis-ci.com/apache/fineract-cn-data-jpa.svg?branch=develop)](https://travis-ci.com/apache/fineract-cn-data-jpa)
+# Apache Fineract CN data-jpa
 
 Data JPA provides easy access to tenant databases.
 


### PR DESCRIPTION
Due to the removal of the Travis build scripts from the project. The build status in the README.md is now misleading and needs to be removed.